### PR TITLE
Add support for `--squash`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /.coverage
 /.env
 /.htmlcov
-/.idea
 /.nox
 /.pytest_cache
 /dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.coverage
 /.env
 /.htmlcov
+/.idea
 /.nox
 /.pytest_cache
 /dist

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 .. note:: This version is not yet released.
 
 * Add support for ``--squash={all|new}`` to squash image layers (podman only).
+* Change default remote image to ``rhel/9.0`` (so squashing works by default).
 
 0.2.0 - 2022-06-21
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 
 .. note:: This version is not yet released.
 
+* Add support for ``--squash={all|new}`` to squash image layers (podman only).
+
 0.2.0 - 2022-06-21
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ quiet = true
 
 [tool.pylint.basic]
 max-line-length = 160
+max-locals = 20
 
 [tool.pylint.reports]
 score = false

--- a/src/containmint.py
+++ b/src/containmint.py
@@ -697,7 +697,7 @@ def parse_args() -> Command:
 
     build_parser = subparsers.add_parser(Build.cli_name(), parents=[common_build_parser], description=Build.__doc__, help=Build.__doc__)
     build_parser.add_argument('--keep-instance', action='store_true', help='keep the remote instance')
-    build_parser.add_argument('--remote', default='ubuntu/22.04', help='ansible-test remote target args')
+    build_parser.add_argument('--remote', default='rhel/9.0', help='ansible-test remote target args')
     build_parser.add_argument('--arch', metavar='ARCH', default='x86_64', choices=['x86_64', 'aarch64'], help='architecture (choices: %(choices)s)')
     build_parser.set_defaults(command_type=Build)
 

--- a/src/containmint.py
+++ b/src/containmint.py
@@ -198,6 +198,7 @@ class Execute(BuildCommand):
 
         if engine.program.name == 'podman':
             options.extend(('--format', 'docker'))
+
             if self.squash == 'all':
                 options.append('--squash-all')
             elif self.squash == 'new':

--- a/test/contexts/simple/Containerfile
+++ b/test/contexts/simple/Containerfile
@@ -1,5 +1,5 @@
 FROM quay.io/bedrock/alpine:3.16.0
 
-RUN date > /etc/timestamp  # force layers to be unique
-RUN uname -a
-RUN . /etc/os-release && echo $NAME
+RUN date | tee /etc/timestamp  # force layers to be unique
+RUN uname -a | tee /etc/uname  # force a second layer to be created for squash testing
+RUN . /etc/os-release && echo $NAME | tee /etc/name  # output must be saved for consistency between docker and podman

--- a/test/contexts/simple/Containerfile
+++ b/test/contexts/simple/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/bedrock/alpine:latest
+FROM quay.io/bedrock/alpine:3.16.0
 
 RUN date > /etc/timestamp  # force layers to be unique
 RUN uname -a

--- a/test/contexts/simple/Containerfile
+++ b/test/contexts/simple/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/bedrock/ubuntu:jammy-20220428
+FROM quay.io/bedrock/alpine:latest
 
 RUN date > /etc/timestamp  # force layers to be unique
 RUN uname -a

--- a/test/requirements/nox.txt
+++ b/test/requirements/nox.txt
@@ -1,7 +1,7 @@
 argcomplete==1.12.3
 colorlog==6.6.0
 distlib==0.3.4
-filelock==3.7.0
+filelock==3.7.1
 nox==2022.1.7
 packaging==21.3
 platformdirs==2.5.2

--- a/test/requirements/pytest.txt
+++ b/test/requirements/pytest.txt
@@ -1,5 +1,5 @@
 attrs==21.4.0
-coverage==6.3.3
+coverage==6.4.1
 iniconfig==1.1.1
 packaging==21.3
 pluggy==1.0.0

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -170,6 +170,7 @@ def test_build(config: Config, credentials: Credentials, remote: str, arch: str,
     # validate non-zero-size layer counts against base image if we squashed to ensure the squash actually occurred
     if squash and squash_supported:
         local_engine = str(containmint.ContainerEngine.detect())
+
         proc = run(local_engine, 'history', '--format=json', get_base_image_from_containerfile(container_file))
         base_layer_count = len([layer for layer in json.loads(proc.stdout) if layer.get('size', 0) > 0])
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -349,6 +349,7 @@ def make_tag(value: str) -> str:
 def get_base_image_from_containerfile(path: str) -> str:
     """Return the first image ref FROM base image from the specified Containerfile."""
     img_re = re.compile(r'FROM (.+)$')
+
     with open(path, 'r', encoding='UTF-8') as reader:
         for line in reader:
             if match := img_re.match(line):

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -169,11 +169,12 @@ def test_build(config: Config, credentials: Credentials, remote: str, arch: str,
 
     # validate non-zero-size layer counts against base image if we squashed to ensure the squash actually occurred
     if squash and squash_supported:
+        local_engine = str(containmint.ContainerEngine.detect())
         # NB: we're currently hardcoding for podman
-        proc = run('podman', 'history', '--format=json', get_base_image_from_containerfile(container_file))
+        proc = run(local_engine, 'history', '--format=json', get_base_image_from_containerfile(container_file))
         base_layer_count = len([layer for layer in json.loads(proc.stdout) if layer.get('size', 0) > 0])
 
-        proc = run('podman', 'manifest', 'inspect', '--log-level=error', tag)
+        proc = run(local_engine, 'manifest', 'inspect', '--log-level=error', tag)
         layer_count = len([layer for layer in json.loads(proc.stdout)['layers'] if layer.get('size', 0) > 0])
 
         if squash == 'new':

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -170,7 +170,6 @@ def test_build(config: Config, credentials: Credentials, remote: str, arch: str,
     # validate non-zero-size layer counts against base image if we squashed to ensure the squash actually occurred
     if squash and squash_supported:
         local_engine = str(containmint.ContainerEngine.detect())
-        # NB: we're currently hardcoding for podman
         proc = run(local_engine, 'history', '--format=json', get_base_image_from_containerfile(container_file))
         base_layer_count = len([layer for layer in json.loads(proc.stdout) if layer.get('size', 0) > 0])
 

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -27,6 +27,7 @@ def test_execute_serialization():
         tag='my_tag',
         push=False,
         login=False,
+        squash='all',
     )
 
     with tempfile.NamedTemporaryFile(prefix='config-', suffix='.json') as config_file:


### PR DESCRIPTION
Add layer squashing support + associated tests
* new arg --squash {all|new} squashes new layers or all layers to significantly reduce final container size
* only supported on podman; full docker support would require 3rd-party `docker-squash` tool or enabling (soft-deprecated) `--squash` option via experimental Docker features
